### PR TITLE
enable http_proxy from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ The Slack Socket Trigger node can be configured with the following options:
 - **Regex Pattern**: Optional regular expression to match against incoming Slack messages
 - **Regex Flags**: Flags for the regular expression (e.g., `g` for global, `i` for case-insensitive)
 
+This node supports using an HTTP or HTTPS proxy by reading the following environment variables:
+
+```bash
+export HTTP_PROXY=http://proxy.example.com:3128
+# or
+export HTTPS_PROXY=http://proxy.example.com:3128
+```
+
 ## Supported Events
 
 The node currently supports the following Slack events:

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     ]
   },
   "dependencies": {
-    "@slack/bolt": "4.4.0"
+    "@slack/bolt": "4.4.0",
+    "http-proxy-agent": "^7.0.2"
   }
 }


### PR DESCRIPTION
We need to access slack via proxy and want to read from environment variable. HTTP_PROXY or HTTPS_PROXY.
Also renamed process to socketProcess as it's conflicted with built-in global `process` object.

similar as this: https://github.com/slackapi/node-slack-sdk/blob/0ddbaf7c1fd3746b0e0c94c4168bea3bef3fd58b/docs/content/migration/migrating-to-v4.md?plain=1#L281