### PR TITLE
Add acknowledgement for block actions from socket to slack

### DIFF
--- a/nodes/SlackSocketTrigger/SlackSocketTrigger.node.ts
+++ b/nodes/SlackSocketTrigger/SlackSocketTrigger.node.ts
@@ -814,7 +814,11 @@ export class SlackSocketTrigger implements INodeType {
 					if (filter === 'message' && regExp) {
 						app.message(regExp, socketProcess);
 					} else if (filter === 'block_actions') {
-						app.action(/.*/, socketProcess);
+						app.action(/.*/, async (args: any) => {
+							const { ack } = args;
+							await ack();
+							await socketProcess(args);
+						});;
 					} else if (filter.startsWith('message.')) {
 						// Handle message subtypes by filtering on channel_type
 						const channelType = filter.replace('message.', '');

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "dependencies": {
     "@slack/bolt": "4.4.0",
-    "http-proxy-agent": "^7.0.2"
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6"
   }
 }


### PR DESCRIPTION
## Missing acknowledgement for block actions

### Brief Overview
For block actions, such as button interaction, Slack expects you to respond to that request with an 200 OK, however, I realised that the current Slack Socket node does not provide acknowledgement. 

Hence, despite the workflow be successful, there seems to have a warning error beside the button, as Slack is not receiving any acknowledgment, as shown in the image below. 

<img width="333" height="122" alt="image" src="https://github.com/user-attachments/assets/840a27fd-5481-471e-abab-deae12740173" />

### Problem: 
As shown from how to [Handle user interaction in your Slack apps](https://docs.slack.dev/interactivity/handling-user-interaction/?utm_source=chatgpt.com), Slack fires a block_actions interaction and expects your app to acknowledge within 3 seconds. If Slack doesn't get that ack, it shows a small warning icon next to the button for the user - even if your n8n later does work and succeeds. 

### Solution
Ensure that the Socket Mode listener acks immediately on block_actions, then let n8n continue the workflow. 