### PR TITLE
adding the view_submission and view_close listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ The node currently supports the following Slack events:
 - `user_resource_granted`: User resource was granted to your app
 - `user_resource_removed`: User resource was removed from your app
 - `user_typing`: A channel member is typing a message
+- `view_submission`: When a modal view is submitted 
+- `view_closed`: When a modal view is closed
 - `workflow_deleted`: A workflow that contains a step supported by your app was deleted
 - `workflow_published`: A workflow that contains a step supported by your app was published
 - `workflow_step_deleted`: A workflow step supported by your app was removed from a workflow

--- a/nodes/SlackSocketTrigger/SlackSocketTrigger.node.ts
+++ b/nodes/SlackSocketTrigger/SlackSocketTrigger.node.ts
@@ -613,6 +613,16 @@ export class SlackSocketTrigger implements INodeType {
 					description: 'When a channel member is typing a message',
 				},
 				{
+					name: 'View Submitted',
+					value: 'view_submission',
+					description: 'When a modal view is submitted (contains submitted values)',
+				},
+				{
+					name: 'View Closed',
+					value: 'view_closed',
+					description: 'When a modal view is closed (contains view details and private_metadata)',
+				},
+				{
 					name: 'Workflow Deleted',
 					value: 'workflow_deleted',
 					description: 'When a workflow that contains a step supported by your app was deleted',
@@ -866,7 +876,9 @@ export class SlackSocketTrigger implements INodeType {
 
 		const socketProcess = async (root: any) => {
 			try {
-				const { body, payload, context, event } = root;
+				// root can contain many keys depending on the interaction: body, payload, context, event, view, etc.
+				// include all non-function keys so view_submission/view_closed payloads are emitted with their view data
+				const event = root?.event;
 
 				if (uniqueChannelIds.length > 0 && event) {
 					const eventChannelId = getEventChannelId(event);
@@ -875,8 +887,16 @@ export class SlackSocketTrigger implements INodeType {
 					}
 				}
 
-				let result: IDataObject = { body, payload, context, event };
-				this.emit([this.helpers.returnJsonArray(result)]);
+				const sanitized: IDataObject = {};
+				for (const key of Object.keys(root)) {
+					const val = root[key];
+					// do not include functions (ack, respond, etc.) as they are not serializable and not useful in the output
+					if (typeof val !== 'function') {
+						sanitized[key] = val as any;
+					}
+				}
+
+				this.emit([this.helpers.returnJsonArray(sanitized)]);
 			} catch (error) {
 				this.logger.error('Error processing Slack Socket event: ' + error);
 			}
@@ -910,6 +930,33 @@ export class SlackSocketTrigger implements INodeType {
 							await ack();
 							await socketProcess(args);
 						});;
+					} else if (filter === 'view_submission') {
+						// listen to any view submission (callback_id matching all) and ack if possible
+						app.view(/.*/, async (args: any) => {
+							try {
+								if (typeof args.ack === 'function') {
+									// acknowledge the view submission so Slack knows we've received it
+									await args.ack();
+								}
+							} catch (err) {
+								this.logger.error('Error acknowledging view_submission: ' + err);
+							}
+							await socketProcess(args);
+						});
+					} else if (filter === 'view_closed') {
+						// listen to view_closed notifications (modal closed). ack might not be required but call if provided.
+						app.view(/.*/, async (args: any) => {
+							// view_closed payloads arrive to the same app.view handler; filter by body?.type or body?.view?.type if needed
+							try {
+								if (typeof args.ack === 'function') {
+									await args.ack();
+								}
+							} catch (err) {
+								// ack may not be required; swallow ack errors but log
+								this.logger.error('view_closed ack error (safe to ignore): ' + err);
+							}
+							await socketProcess(args);
+						});
 					} else if (filter.startsWith('message.')) {
 						// Handle message subtypes by filtering on channel_type
 						const channelType = filter.replace('message.', '');

--- a/nodes/SlackSocketTrigger/SlackSocketTrigger.node.ts
+++ b/nodes/SlackSocketTrigger/SlackSocketTrigger.node.ts
@@ -936,7 +936,6 @@ export class SlackSocketTrigger implements INodeType {
 							try {
 								this.logger.info('view_submission recieved');
 								if (typeof args.ack === 'function') {
-									// acknowledge the view submission so Slack knows we've received it
 									await args.ack();
 								}
 							} catch (err) {
@@ -947,14 +946,12 @@ export class SlackSocketTrigger implements INodeType {
 					} else if (filter === 'view_closed') {
 						// listen to view_closed notifications (modal closed). ack might not be required but call if provided.
 						app.view({type: 'view_closed' }, async (args: any) => {
-							// view_closed payloads arrive to the same app.view handler; filter by body?.type or body?.view?.type if needed
 							try {
 								this.logger.info('view_closed recieved');
 								if (typeof args.ack === 'function') {
 									await args.ack();
 								}
 							} catch (err) {
-								// ack may not be required; swallow ack errors but log
 								this.logger.error('view_closed ack error (safe to ignore): ' + err);
 							}
 


### PR DESCRIPTION
added the ability to listen to 2 new slack events view_submission and view_close (helpful when we want to control the flow of user forms in slack from n8n)