### PR TITLE
fix: bundle Slack runtime deps to make community-node install deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,11 @@
     "@slack/socket-mode": "^2.0.5",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6"
-  }
+  },
+  "bundleDependencies": [
+    "@slack/bolt",
+    "@slack/socket-mode",
+    "http-proxy-agent",
+    "https-proxy-agent"
+  ]
 }


### PR DESCRIPTION
## Summary

Fixes #14.

n8n installs community packages with `--install-strategy=shallow`, which disables npm's normal dependency hoisting and forces transitive deps into deeply nested per-package `node_modules` trees. Under that install strategy, in some npm/cache states a nested copy of `@slack/socket-mode` ends up under `@slack/bolt/node_modules/` *without* its `dist/` extracted, and n8n's package loader fails with:

```
ENOENT: no such file or directory, open
'.../n8n-nodes-slack-socket-mode/node_modules/@slack/bolt/node_modules/@slack/socket-mode/dist/src/index.js'
```

n8n's lifecycle service auto-uninstalls the package after the load failure, so the node is permanently unusable for affected users until the install path itself is made deterministic.

## Change

Add `bundleDependencies` listing the four runtime deps (`@slack/bolt`, `@slack/socket-mode`, `http-proxy-agent`, `https-proxy-agent`) so they are shipped pre-extracted inside the published tarball. npm then does not need to resolve them transitively at install time, and the install becomes deterministic regardless of install strategy or npm cache state.

```diff
   "dependencies": {
     "@slack/bolt": "^4.6.0",
     "@slack/socket-mode": "^2.0.5",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6"
-  }
+  },
+  "bundleDependencies": [
+    "@slack/bolt",
+    "@slack/socket-mode",
+    "http-proxy-agent",
+    "https-proxy-agent"
+  ]
 }
```

## Tradeoffs

- Tarball size grows from ~30 KB to ~2.5 MB. Slack's runtime SDK is the bulk of that; users were paying that disk cost already, just resolved at install time instead of bake time.
- Top-level deps are still listed in `dependencies` (npm requires this when using `bundleDependencies`), so semver and Dependabot continue to work as before. Bumping a Slack dep is a one-line change followed by `npm install` + `npm pack`.
- A more aggressive alternative is bundling everything into `dist/` via esbuild/tsup; that produces a smaller tarball but is a larger refactor. `bundleDependencies` is the minimum-diff fix that solves the underlying install determinism problem.

## Verification

Packed the branch locally and installed the resulting tarball with the exact flags n8n uses inside an n8n container (`node 24.14.1`, `npm 11.12.1`):

```
npm install ./mbakgun-n8n-nodes-slack-socket-mode-1.7.0.tgz \
  --bin-links=false --install-strategy=shallow \
  --ignore-scripts=true --package-lock=false
```

Result: `@slack/socket-mode/dist/src/index.js` is present at the expected path, and both `@slack/bolt` and `@slack/socket-mode` `require()` cleanly under the package root.

## Notes

- Version field is unchanged — happy to bump to `1.7.1` (or whatever you'd like) before publish.
- I skipped editing the README; the install instructions don't change for end users.

Disclosure: this PR was prepared with the help of Claude (issue investigation, repro, and writeup). The diff is small and reviewable; happy to iterate.